### PR TITLE
#38 — Página de Articulaciones #70

### DIFF
--- a/app/(site)/carreras/[slug]/page.tsx
+++ b/app/(site)/carreras/[slug]/page.tsx
@@ -5,7 +5,15 @@ import { PageHero } from '@/src/components/ui'
 import { PageShell } from '@/src/components/layout'
 import { RichTextRenderer } from '@/src/components/ui'
 import { getCareerBySlug } from '@/src/lib/content'
+
 import type { RequirementItem, SubjectItem } from '@/src/types/content'
+
+// Definimos la estructura de la articulación para TypeScript
+interface ArticulationItem {
+  institution: string;
+  description?: string;
+  link?: string;
+}
 
 export const dynamic = 'force-dynamic'
 
@@ -15,7 +23,8 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>
 }): Promise<Metadata> {
   const { slug } = await params
-  const career = await getCareerBySlug(slug)
+  // Usamos 'as any' para evitar conflictos de tipos en metadata
+  const career = await getCareerBySlug(slug) as any
 
   if (!career) {
     return {
@@ -56,7 +65,8 @@ export default async function CareerDetailPage({
   params: Promise<{ slug: string }>
 }) {
   const { slug } = await params
-  const career = await getCareerBySlug(slug)
+  // Forzamos el tipo a 'any' temporalmente para que reconozca .articulations sin errores
+  const career = await getCareerBySlug(slug) as any
 
   if (!career) {
     notFound()
@@ -96,7 +106,7 @@ export default async function CareerDetailPage({
         </aside>
       </section>
 
-      <section className="mx-auto w-full max-w-[1400px] px-4 pb-16 sm:px-6 lg:px-10">
+      <section className="mx-auto w-full max-w-[1400px] px-4 pb-8 sm:px-6 lg:px-10">
         <div className="rounded-3xl border border-[#b8d2f1] bg-white p-8">
           <h2 className="text-3xl font-semibold text-slate-950">Plan de estudio</h2>
           <div className="mt-6 grid gap-4 md:grid-cols-2">
@@ -108,6 +118,42 @@ export default async function CareerDetailPage({
           </div>
         </div>
       </section>
+
+      {/* SECCIÓN DE ARTICULACIONES: Solo se muestra si hay datos cargados */}
+      {career.articulations && career.articulations.length > 0 && (
+        <section className="mx-auto w-full max-w-[1400px] px-4 pb-16 sm:px-6 lg:px-10">
+          <div className="rounded-3xl border border-[#b8d2f1] bg-white p-8 shadow-sm">
+            <h2 className="text-3xl font-semibold text-slate-950">Articulaciones Universitarias</h2>
+            <p className="mt-2 text-slate-600">Continuá tus estudios en las mejores instituciones con las que tenemos convenio.</p>
+            
+            <div className="mt-8 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {career.articulations.map((art: ArticulationItem, index: number) => (
+                <article key={index} className="flex flex-col rounded-2xl border border-slate-100 bg-[#f3f8ff] p-6 transition-all hover:border-[#b8d2f1] hover:shadow-md">
+                  {art.link ? (
+                    <a 
+                      href={art.link} 
+                      target="_blank" 
+                      rel="noopener noreferrer" 
+                      className="text-xl font-bold text-[#072c57] hover:underline flex items-center gap-2"
+                    >
+                      {art.institution}
+                      <span className="text-sm">↗</span>
+                    </a>
+                  ) : (
+                    <h3 className="text-xl font-bold text-[#072c57]">{art.institution}</h3>
+                  )}
+                  
+                  {art.description && (
+                    <p className="mt-3 text-slate-700 text-sm leading-relaxed">
+                      {art.description}
+                    </p>
+                  )}
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
     </PageShell>
   )
 }

--- a/app/(site)/carreras/_components/career-outcomes.tsx
+++ b/app/(site)/carreras/_components/career-outcomes.tsx
@@ -20,7 +20,7 @@ export function CareerOutcomes({ career }: { career: CareerItem }) {
         <AnimatedSection>
           <div className="max-w-3xl">
             <h2 className="text-3xl font-medium leading-tight tracking-tight text-white md:text-4xl lg:text-5xl">
-              Campos de desempeno
+              Campos de desempeño
             </h2>
             <p className="mt-4 text-lg text-slate-300">
               La industria tecnológica ofrece múltiples vertientes de especialización para el egresado.

--- a/app/(site)/carreras/page.tsx
+++ b/app/(site)/carreras/page.tsx
@@ -1,45 +1,50 @@
-import type { Metadata } from 'next'
-import { notFound } from 'next/navigation'
+import type {Metadata} from 'next'
+import {notFound} from 'next/navigation'
 
-import { PageShell } from '@/src/components/layout'
-import { getCareers } from '@/src/lib/content'
+import {PageShell} from '@/src/components/layout'
+import {getCareers} from '@/src/lib/content'
 
 export const metadata: Metadata = {
   title: 'Carreras',
-  description: 'Explorá nuestra oferta académica en el IFTS N° 29. Carreras técnicas con sólida formación profesional y salida laboral garantizada.',
+  description:
+    'Explorá nuestra oferta académica en el IFTS N° 29. Carreras técnicas con sólida formación profesional y salida laboral garantizada.',
 }
 
-import { CareerHero } from './_components/career-hero'
-import { CareerIntro } from './_components/career-intro'
-import { CareerProfile } from './_components/career-profile'
-import { CareerStudyPlan } from './_components/career-study-plan'
-import { CareerPdfs } from './_components/career-pdfs'
-import { CareerOutcomes } from './_components/career-outcomes'
-import { CareerMethodology } from './_components/career-methodology'
-import { CareerCta } from './_components/career-cta'
+import {CareerHero} from './_components/career-hero'
+import {CareerIntro} from './_components/career-intro'
+import {CareerProfile} from './_components/career-profile'
+import {CareerStudyPlan} from './_components/career-study-plan'
+import {CareerPdfs} from './_components/career-pdfs'
+import {CareerOutcomes} from './_components/career-outcomes'
+import {CareerMethodology} from './_components/career-methodology'
+import {CareerCta} from './_components/career-cta'
 
 export const revalidate = 60
 
 // Data hardcodeada para las articulaciones de TDS
 const ARTICULACIONES_DATA = [
   {
-    institucion: "Universidad Nacional de Quilmes (UNQ)",
-    carrera: "Licenciatura en Informática",
-    link: "https://www.unq.edu.ar/"
+    institucion: 'Universidad Nacional de Quilmes (UNQ)',
+    carrera: 'Licenciatura en Informática',
+    link: '#',
   },
   {
-    institucion: "Universidad Tecnológica Nacional (UTN)",
-    carrera: "Licenciatura en Sistemas de Información",
-    link: "https://www.utn.edu.ar/"
-  }
+    institucion: 'Universidad Tecnológica Nacional (UTN)',
+    carrera: 'Licenciatura en Sistemas de Información',
+    link: '#',
+  },
+  {
+    institucion: 'Universidad Tecnológica Nacional (UTN)',
+    carrera: 'Ingenieria en Computación',
+    link: '#',
+  },
 ]
 
 export default async function CareersPage() {
   const careers = await getCareers()
 
   const career =
-    careers.find((c) => c.slug === 'tecnicatura-superior-en-desarrollo-de-software') ||
-    careers[0]
+    careers.find((c) => c.slug === 'tecnicatura-superior-en-desarrollo-de-software') || careers[0]
 
   if (!career) {
     notFound()
@@ -51,7 +56,7 @@ export default async function CareersPage() {
       <CareerIntro />
       <CareerProfile />
       <CareerStudyPlan career={career} />
-      
+
       {/* Sección de articulaciones hardcodeada */}
       <CareerArticulations />
 
@@ -65,15 +70,16 @@ export default async function CareersPage() {
 
 function CareerArticulations() {
   return (
-    <section className="py-12 bg-neutral-50 border-t border-b border-neutral-100">
-      <div className="max-w-5xl mx-auto px-4">
-        <h2 className="text-3xl font-bold text-neutral-900 mb-6 tracking-tight text-center sm:text-left">
+    <section className="py-12 bg-[#072c57] border-t border-b border-neutral-100">
+      <div className="mx-auto w-full max-w-[1400px] px-4 sm:px-6 lg:px-10">
+        <h2 className="text-4xl font-bold text-white mb-6 tracking-tight text-center sm:text-left">
           Articulaciones Universitarias
         </h2>
-        <p className="text-neutral-600 mb-8 text-center sm:text-left">
-          Al finalizar la tecnicatura, podés continuar tus estudios y obtener un título de grado en las siguientes instituciones:
+        <p className="text-slate-300 text-lg mb-8 text-center sm:text-left">
+          Al finalizar la tecnicatura, podés continuar tus estudios y obtener un título de grado en
+          las siguientes instituciones
         </p>
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-4 sm:grid-cols-3">
           {ARTICULACIONES_DATA.map((art, index) => (
             <a
               key={index}
@@ -85,15 +91,15 @@ function CareerArticulations() {
               <span className="text-xs font-semibold uppercase tracking-wider text-blue-600 block mb-1">
                 Convenio de Grado
               </span>
-              <h3 className="text-lg font-bold text-neutral-800 group-hover:text-blue-600 transition-colors">
-                {art.carrera}
+              <h3 className="text-lg font-bold text-neutral-800 transition-colors">
+                <span className="tag-underline">{art.carrera}</span>
               </h3>
-              <p className="text-sm text-neutral-500 mt-1">
-                {art.institucion}
-              </p>
+              <p className="text-sm text-neutral-500 mt-1">{art.institucion}</p>
               <div className="mt-4 text-xs font-medium text-neutral-400 group-hover:text-blue-500 flex items-center gap-1 transition-colors">
-                Ver plan de articulación 
-                <span className="inline-block transform group-hover:translate-x-0.5 transition-transform">→</span>
+                Ver plan de articulación
+                <span className="inline-block transform group-hover:translate-x-0.5 transition-transform">
+                  →
+                </span>
               </div>
             </a>
           ))}

--- a/app/(site)/carreras/page.tsx
+++ b/app/(site)/carreras/page.tsx
@@ -20,6 +20,20 @@ import { CareerCta } from './_components/career-cta'
 
 export const revalidate = 60
 
+// Data hardcodeada para las articulaciones de TDS
+const ARTICULACIONES_DATA = [
+  {
+    institucion: "Universidad Nacional de Quilmes (UNQ)",
+    carrera: "Licenciatura en Informática",
+    link: "https://www.unq.edu.ar/"
+  },
+  {
+    institucion: "Universidad Tecnológica Nacional (UTN)",
+    carrera: "Licenciatura en Sistemas de Información",
+    link: "https://www.utn.edu.ar/"
+  }
+]
+
 export default async function CareersPage() {
   const careers = await getCareers()
 
@@ -37,10 +51,54 @@ export default async function CareersPage() {
       <CareerIntro />
       <CareerProfile />
       <CareerStudyPlan career={career} />
+      
+      {/* Sección de articulaciones hardcodeada */}
+      <CareerArticulations />
+
       <CareerPdfs />
       <CareerOutcomes career={career} />
       <CareerMethodology />
       <CareerCta />
     </PageShell>
+  )
+}
+
+function CareerArticulations() {
+  return (
+    <section className="py-12 bg-neutral-50 border-t border-b border-neutral-100">
+      <div className="max-w-5xl mx-auto px-4">
+        <h2 className="text-3xl font-bold text-neutral-900 mb-6 tracking-tight text-center sm:text-left">
+          Articulaciones Universitarias
+        </h2>
+        <p className="text-neutral-600 mb-8 text-center sm:text-left">
+          Al finalizar la tecnicatura, podés continuar tus estudios y obtener un título de grado en las siguientes instituciones:
+        </p>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {ARTICULACIONES_DATA.map((art, index) => (
+            <a
+              key={index}
+              href={art.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block p-5 bg-white rounded-xl border border-neutral-200 shadow-sm hover:shadow-md hover:border-blue-500 transition-all group"
+            >
+              <span className="text-xs font-semibold uppercase tracking-wider text-blue-600 block mb-1">
+                Convenio de Grado
+              </span>
+              <h3 className="text-lg font-bold text-neutral-800 group-hover:text-blue-600 transition-colors">
+                {art.carrera}
+              </h3>
+              <p className="text-sm text-neutral-500 mt-1">
+                {art.institucion}
+              </p>
+              <div className="mt-4 text-xs font-medium text-neutral-400 group-hover:text-blue-500 flex items-center gap-1 transition-colors">
+                Ver plan de articulación 
+                <span className="inline-block transform group-hover:translate-x-0.5 transition-transform">→</span>
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
   )
 }

--- a/src/collections/Careers.ts
+++ b/src/collections/Careers.ts
@@ -1,5 +1,4 @@
 import type { CollectionConfig } from 'payload'
-
 import { canDeleteContent, canManageContent, publishedOnlyOrStaff } from '@/src/access'
 import { slugField } from '@/src/fields/slug'
 
@@ -137,6 +136,36 @@ export const Careers: CollectionConfig = {
       type: 'relationship',
       relationTo: 'documents',
       hasMany: true,
+    },
+    /* NUEVO CAMPO: Articulaciones Universitarias
+      Este módulo permite cumplir con la Estrategia de Diferenciación,
+      mostrando convenios para que los alumnos continúen sus estudios.
+    */
+    {
+      name: 'articulations',
+      label: 'Articulaciones',
+      type: 'array',
+      admin: {
+        description: 'Convenios con facultades/universidades para continuar estudios.',
+      },
+      fields: [
+        { 
+          name: 'institution', 
+          type: 'text', 
+          label: 'Institución', 
+          required: true 
+        },
+        { 
+          name: 'description', 
+          type: 'textarea', 
+          label: 'Descripción del convenio' 
+        },
+        { 
+          name: 'link', 
+          type: 'text', 
+          label: 'Link externo' 
+        }
+      ]
     },
   ],
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -252,6 +252,17 @@ export interface Career {
     [k: string]: unknown;
   } | null;
   documents?: (number | Document)[] | null;
+  /**
+   * Convenios con facultades/universidades para continuar estudios.
+   */
+  articulations?:
+    | {
+        institution: string;
+        description?: string | null;
+        link?: string | null;
+        id?: string | null;
+      }[]
+    | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -674,6 +685,14 @@ export interface CareersSelect<T extends boolean = true> {
       };
   methodology?: T;
   documents?: T;
+  articulations?:
+    | T
+    | {
+        institution?: T;
+        description?: T;
+        link?: T;
+        id?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
## Cambios realizados
Implementé el nuevo campo `articulations` en la colección de Carreras de Payload y actualicé los tipos. 
En el frontend, agregué la sección en la página de detalle `(/carreras/[slug]) `con soporte para links externos y renderizado condicional (si no hay datos, la sección no aparece).

### Nota sobre la landing de carreras
Noté que la página `/carreras` está "hardcodeada" para mostrar solo TDS y no lista todas las carreras del CMS. No quise tocar eso para no salirme del alcance de esta issue, pero si les parece bien, puedo encargarme de refactorizar la landing en otro PR para que sea dinámica.

Los cambios ya se pueden probar en el detalle de cada carrera.