### PR TITLE
feat: agregar sección de horarios de cursada en detalle de carrera

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "folder-color.pathColors": []
+}

--- a/app/(site)/carreras/[slug]/page.tsx
+++ b/app/(site)/carreras/[slug]/page.tsx
@@ -1,3 +1,4 @@
+// app/(site)/careers/[slug]/page.tsx
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 
@@ -6,6 +7,9 @@ import { PageShell } from '@/src/components/layout'
 import { RichTextRenderer } from '@/src/components/ui'
 import { getCareerBySlug } from '@/src/lib/content'
 import type { RequirementItem, SubjectItem } from '@/src/types/content'
+
+// Importamos el nuevo componente de horarios
+import ScheduleTable from '@/app/(site)/carreras/_components/ScheduleTable'
 
 export const dynamic = 'force-dynamic'
 
@@ -96,7 +100,8 @@ export default async function CareerDetailPage({
         </aside>
       </section>
 
-      <section className="mx-auto w-full max-w-[1400px] px-4 pb-16 sm:px-6 lg:px-10">
+      {/* Sección Plan de estudio */}
+      <section className="mx-auto w-full max-w-[1400px] px-4 pb-8 sm:px-6 lg:px-10">
         <div className="rounded-3xl border border-[#b8d2f1] bg-white p-8">
           <h2 className="text-3xl font-semibold text-slate-950">Plan de estudio</h2>
           <div className="mt-6 grid gap-4 md:grid-cols-2">
@@ -108,6 +113,15 @@ export default async function CareerDetailPage({
           </div>
         </div>
       </section>
+
+      {/* NUEVA SECCIÓN: Horarios de cursada */}
+      <section className="mx-auto w-full max-w-[1400px] px-4 pb-16 sm:px-6 lg:px-10">
+        <div className="rounded-3xl border border-[#b8d2f1] bg-white p-8">
+          {/* Invocamos la tabla pasando el slug resuelto */}
+          <ScheduleTable carreraSlug={slug} />
+        </div>
+      </section>
+      
     </PageShell>
-  )
+  );
 }

--- a/app/(site)/carreras/_components/ScheduleTable.tsx
+++ b/app/(site)/carreras/_components/ScheduleTable.tsx
@@ -1,0 +1,56 @@
+// app/(site)/careers/_components/ScheduleTable.tsx
+import React from 'react';
+
+// Definimos los horarios por carrera para cumplir el criterio de aceptación
+const SCHEDULES_BY_CARRERA: Record<string, Array<{ time: string; lunes: string; martes: string; miercoles: string; jueves: string; viernes: string; }>> = {
+  // Supongamos que el slug de tu carrera actual es 'desarrollo-software' o 'tecnicatura-software'
+  'tecnicatura-en-desarrollo-en-software': [
+    { time: '18:30 - 20:30', lunes: 'Matemática', martes: '-', miercoles: 'Matemática', jueves: '-', viernes: '-' },
+    { time: '20:30 - 22:30', lunes: 'Programación', martes: '-', miercoles: 'Programación', jueves: '-', viernes: '-' },
+  ],
+  // Otras carreras que tengan horarios se agregan acá. Si no están en este objeto, no mostrarán nada.
+};
+
+interface ScheduleTableProps {
+  carreraSlug: string;
+}
+
+export default function ScheduleTable({ carreraSlug }: ScheduleTableProps) {
+  const scheduleData = SCHEDULES_BY_CARRERA[carreraSlug];
+
+  // CRITERIO DE ACEPTACIÓN: Si no hay horarios configurados para este slug, la sección NO se muestra
+  if (!scheduleData || scheduleData.length === 0) return null;
+
+  return (
+    <div className="w-full my-8">
+      <h3 className="text-2xl font-bold mb-4 text-[#072c57]">Horarios de cursada</h3>
+      
+      <div className="w-full overflow-x-auto rounded-xl border border-slate-200 shadow-sm">
+        <table className="w-full min-w-[600px] border-collapse text-left text-sm text-slate-700">
+          <thead>
+            <tr className="bg-[#072c57] text-white">
+              <th className="p-4 font-semibold tracking-wide">Horario</th>
+              <th className="p-4 font-semibold tracking-wide">Lunes</th>
+              <th className="p-4 font-semibold tracking-wide">Martes</th>
+              <th className="p-4 font-semibold tracking-wide">Miércoles</th>
+              <th className="p-4 font-semibold tracking-wide">Jueves</th>
+              <th className="p-4 font-semibold tracking-wide">Viernes</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {scheduleData.map((row, index) => (
+              <tr key={index} className="bg-[#f3f8ff] hover:bg-blue-50/50 transition-colors">
+                <td className="p-4 font-medium text-[#072c57] whitespace-nowrap">{row.time}</td>
+                <td className="p-4 whitespace-nowrap">{row.lunes}</td>
+                <td className="p-4 whitespace-nowrap">{row.martes}</td>
+                <td className="p-4 whitespace-nowrap">{row.miercoles}</td>
+                <td className="p-4 whitespace-nowrap">{row.jueves}</td>
+                <td className="p-4 whitespace-nowrap">{row.viernes}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Descripción
Este PR resuelve la issue #71, integrando la nueva sección **"Horarios de cursada"** dentro de la página de detalle de cada carrera (`app/(site)/carreras/[slug]/page.tsx`). 

Se implementó siguiendo los requerimientos de diseño, paleta de colores del sitio y asegurando que la experiencia sea completamente responsive.

## Cambios realizados
- **Creación del componente `ScheduleTable`** en `app/(site)/carreras/_components/ScheduleTable.tsx`:
  - Renderiza una tabla estructurada con los días de la semana como columnas y los bloques horarios como filas.
  - Se aplicaron los estilos requeridos: cabeceras con color institucional (`#072c57`), fondo de celdas (`#f3f8ff`) y bordes redondeados.
- **Integración en `app/(site)/carreras/[slug]/page.tsx`**:
  - Se acopló la sección de forma nativa debajo del bloque de *Plan de estudio*, manteniendo la coherencia visual con el resto de las tarjetas de la interfaz.

## Criterios de aceptación verificados
- [x] **Visibilidad:** La sección se muestra correctamente en la página de detalle de la carrera.
- [x] **Diseño Responsive:** La tabla está contenida en un bloque con `overflow-x-auto` y un ancho mínimo establecido, garantizando que en dispositivos móviles se active un scroll horizontal sutil sin romper el layout general.
- [x] **Criterio de ocultación:** El componente recibe el `slug` por props y valida contra el diccionario de datos. Si una carrera no tiene horarios configurados (ej. cualquier otra que no sea la de prueba), el componente retorna `null` y la sección no se renderiza en el DOM, cumpliendo estrictamente con la regla de negocio.

## Capturas de pantalla (Localhost)
| Vista Desktop |
| ------------- |
<img width="1920" height="2233" alt="image" src="https://github.com/user-attachments/assets/50b29865-0b5a-471e-a975-c1fc21b0a37a" />

Closes #39